### PR TITLE
feat: Implement 'Add New Model' functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Ignore the temporary simulation output directory
 temp_sim/
 
+# Ignore user-added model files
+user_models/
+
 # Ignore any generated netlist files
 *.net
 

--- a/src/engines/analysis.py
+++ b/src/engines/analysis.py
@@ -21,6 +21,32 @@ class VthExtractor:
         self.raw_file_path = raw_file_path
         self.ltr = RawRead(self.raw_file_path)
 
+    def _find_drain_current_trace(self):
+        """
+        Attempts to find the drain current trace using a list of common names.
+        This handles variations in SPICE model pin naming (D vs DRAIN).
+        """
+        # Get all available traces from the raw file
+        all_traces = self.ltr.get_trace_names()
+        
+        # A list of possible drain current names to try, in order of preference
+        possible_names = [
+            "Ix(xu1:D)",      # Common convention (lowercase)
+            "Ix(xu1:DRAIN)",  # Explicit pin name convention
+            "Id(XU1)",        # Another common convention
+            "Id(M1)"          # If the MOSFET is a simple M device
+        ]
+
+        for name in possible_names:
+            # Check if this name exists in the list of available traces (case-insensitive)
+            for trace in all_traces:
+                if trace.lower() == name.lower():
+                    print(f"Found drain current trace: '{trace}'")
+                    return self.ltr.get_trace(trace) # Return the trace object
+        
+        # If no match was found after checking all possibilities
+        raise RuntimeError(f"Could not find a valid drain current trace. Available traces: {all_traces}")
+
     def extract_vth_at_25c(self, target_current=1e-3):
         """
         Finds Vgs(th) and returns the results and raw data in a dictionary.
@@ -36,7 +62,7 @@ class VthExtractor:
         
         # This can now raise an exception that the engine will catch
         vgs_trace = self.ltr.get_trace("V(v_g_d)")
-        id_trace = self.ltr.get_trace("Ix(xu1:D)")
+        id_trace = self._find_drain_current_trace()
         
         vgs_wave = vgs_trace.get_wave(step_idx).astype(float)
         id_wave = id_trace.get_wave(step_idx).astype(float)

--- a/src/engines/pyltspice_engine.py
+++ b/src/engines/pyltspice_engine.py
@@ -47,6 +47,9 @@ class PyLTSpiceEngine(AbstractSimulationEngine):
         
         self.runner.output_folder = output_dir
 
+        netlist_path = None
+        log_file = None
+
         try:
             netlist_path = self.runner.create_netlist(asc_file_path)
             if not netlist_path:
@@ -66,11 +69,7 @@ class PyLTSpiceEngine(AbstractSimulationEngine):
             
             if not raw_file:
                 # In case of failure, read the log for a more detailed error
-                log_content = ""
-                if log_file and os.path.exists(log_file):
-                    with open(log_file, 'r') as f:
-                        log_content = f.read()
-                raise RuntimeError(f"Simulation failed. Log: {log_content}")
+                raise RuntimeError("Simulation failed to produce a .raw file.")
 
             # If simulation is successful, run the analysis
             extractor = VthExtractor(raw_file_path=raw_file)
@@ -87,7 +86,10 @@ class PyLTSpiceEngine(AbstractSimulationEngine):
             return json.dumps(output_data, indent=4)
 
         except Exception as e:
-            # If anything fails, return a standardized error JSON
+            # If anything fails during the process, catch the exception
+            # and return a standardized error JSON. The full traceback
+            # will still be printed to the console by the main worker thread.
+            print(f"An error occurred in the simulation engine: {e}") # A simple log
             error_data = {
                 "status": "error",
                 "model_name": model_info['name'],


### PR DESCRIPTION
### Summary

This pull request implements the full functionality for **User Story 2: Add a new model**. It provides a complete, end-to-end workflow for users to add their own custom SPICE models to the application library.

This is the first feature of the Sprint 2 "Comparison Workflow" and builds upon the newly refactored, compliant architecture.

### Key Changes Implemented

1.  **File Dialog:** A "File > Add Model..." menu action has been added, which opens a standard `QFileDialog` for selecting `.lib` or `.mod` files.
2.  **Model Import Logic:**
    - Selected model files are copied to a dedicated `/user_models` directory (which is correctly ignored by `.gitignore`).
    - The application intelligently parses the model file to find the correct `.SUBCKT` name, rather than relying on the filename. This makes the import process significantly more robust.
    - The `models.json` config file is updated with the new model's name and its **absolute path**, ensuring the simulation engine can always find it.
3.  **UI Refresh:** The MOSFET model dropdown list is automatically refreshed to display the newly added model without requiring an application restart.
4.  **Enhanced Analysis Module:** The `VthExtractor` has been made more flexible. It now correctly parses `.raw` files from models that use different pin naming conventions (e.g., `DRAIN` vs. `D`), which was a key learning from testing this feature.
5.  **Documentation:** The `DEVELOPER_NOTES.md` has been updated to capture the critical lessons learned about absolute paths and trace pin naming.

### How to Test

1.  Launch the application.
2.  Go to "File > Add Model..." and select a custom `.lib` or `.mod` file.
3.  **Expected Result 1:** The model is copied to the `/user_models` folder, `models.json` is updated, and the new model name appears in the UI dropdown.
4.  Select the newly added model and click "Run Simulation".
5.  **Expected Result 2:** The simulation runs successfully using the new model, and a valid Vgs(th) result is displayed.